### PR TITLE
Bug Fix

### DIFF
--- a/template/include/default.html
+++ b/template/include/default.html
@@ -5,7 +5,7 @@ html {
 }
 /* style of "before" */
 /** before plain or definition **/
-.Theorem:before,.Lemma:before,.Proposition:before,.Corollary:before,.Definition:before,.Conjecture:before,.Example:before,.Postulate:before,.Problem:before,.dump:before
+.Theorem:before,.Lemma:before,.Proposition:before,.Corollary:before,.Definition:before,.Conjecture:before,.Example:before,.Postulate:before,.Problem:before,.proof:before
 {
 	font-weight:700;
 	font-style:normal
@@ -77,7 +77,7 @@ html {
 }
 /* main style */
 /** plain **/
-.Theorem,.Lemma,.Proposition,.Corollary,,.dump
+.Theorem,.Lemma,.Proposition,.Corollary,,.proof
 {
 	display:block;
 	margin:12px 0;

--- a/template/include/default.html
+++ b/template/include/default.html
@@ -11,7 +11,7 @@ html {
 	font-style:normal
 }
 /** before remark or proof **/
-.Case:before,.Remark:before,.Note:before,.Proof:before
+.Case:before,.Remark:before,.Note:before,.proof:before
 {
 	font-style:italic
 }

--- a/template/include/pandoc-amsthm.html
+++ b/template/include/pandoc-amsthm.html
@@ -12,7 +12,7 @@ $for(amsthm.plain)$.$amsthm.plain$:before,$endfor$$for(amsthm.plain-unnumbered)$
 	font-style:normal
 }
 /** before remark or proof **/
-$for(amsthm.remark)$.$amsthm.remark$:before,$endfor$$for(amsthm.remark-unnumbered)$.$amsthm.remark-unnumbered$:before,$endfor$.Proof:before
+$for(amsthm.remark)$.$amsthm.remark$:before,$endfor$$for(amsthm.remark-unnumbered)$.$amsthm.remark-unnumbered$:before,$endfor$.proof:before
 {
 	font-style:italic
 }

--- a/template/include/pandoc-amsthm.html
+++ b/template/include/pandoc-amsthm.html
@@ -6,7 +6,7 @@ html {
 }
 /* style of "before" */
 /** before plain or definition **/
-$for(amsthm.plain)$.$amsthm.plain$:before,$endfor$$for(amsthm.plain-unnumbered)$.$amsthm.plain-unnumbered$:before,$endfor$$for(amsthm.definition)$.$amsthm.definition$:before,$endfor$$for(amsthm.definition-unnumbered)$.$amsthm.definition-unnumbered$:before,$endfor$.dump:before
+$for(amsthm.plain)$.$amsthm.plain$:before,$endfor$$for(amsthm.plain-unnumbered)$.$amsthm.plain-unnumbered$:before,$endfor$$for(amsthm.definition)$.$amsthm.definition$:before,$endfor$$for(amsthm.definition-unnumbered)$.$amsthm.definition-unnumbered$:before,$endfor$.proof:before
 {
 	font-weight:700;
 	font-style:normal
@@ -62,7 +62,7 @@ $endfor$
 }
 /* main style */
 /** plain **/
-$for(amsthm.plain)$.$amsthm.plain$,$endfor$$for(amsthm.plain-unnumbered)$.$amsthm.plain-unnumbered$,$endfor$,.dump
+$for(amsthm.plain)$.$amsthm.plain$,$endfor$$for(amsthm.plain-unnumbered)$.$amsthm.plain-unnumbered$,$endfor$,.proof
 {
 	display:block;
 	margin:12px 0;

--- a/template/pandoc-amsthm.html
+++ b/template/pandoc-amsthm.html
@@ -32,7 +32,7 @@ $if(amsthm)$
   	font-style:normal
   }
   /** before remark or proof **/
-  $for(amsthm.remark)$.$amsthm.remark$:before,$endfor$$for(amsthm.remark-unnumbered)$.$amsthm.remark-unnumbered$:before,$endfor$.Proof:before
+  $for(amsthm.remark)$.$amsthm.remark$:before,$endfor$$for(amsthm.remark-unnumbered)$.$amsthm.remark-unnumbered$:before,$endfor$.proof:before
   {
   	font-style:italic
   }

--- a/template/pandoc-amsthm.html
+++ b/template/pandoc-amsthm.html
@@ -26,7 +26,7 @@ $if(amsthm)$
   }
   /* style of "before" */
   /** before plain or definition **/
-  $for(amsthm.plain)$.$amsthm.plain$:before,$endfor$$for(amsthm.plain-unnumbered)$.$amsthm.plain-unnumbered$:before,$endfor$$for(amsthm.definition)$.$amsthm.definition$:before,$endfor$$for(amsthm.definition-unnumbered)$.$amsthm.definition-unnumbered$:before,$endfor$.dump:before
+  $for(amsthm.plain)$.$amsthm.plain$:before,$endfor$$for(amsthm.plain-unnumbered)$.$amsthm.plain-unnumbered$:before,$endfor$$for(amsthm.definition)$.$amsthm.definition$:before,$endfor$$for(amsthm.definition-unnumbered)$.$amsthm.definition-unnumbered$:before,$endfor$.proof:before
   {
   	font-weight:700;
   	font-style:normal
@@ -82,7 +82,7 @@ $endfor$
   }
   /* main style */
   /** plain **/
-  $for(amsthm.plain)$.$amsthm.plain$,$endfor$$for(amsthm.plain-unnumbered)$.$amsthm.plain-unnumbered$,$endfor$,.dump
+  $for(amsthm.plain)$.$amsthm.plain$,$endfor$$for(amsthm.plain-unnumbered)$.$amsthm.plain-unnumbered$,$endfor$,.proof
   {
   	display:block;
   	margin:12px 0;


### PR DESCRIPTION
using the cascading property of CSS to get around with the .dump
problem (.dump was introduced to avoid ending in `,`)